### PR TITLE
add extension for SugarSS

### DIFF
--- a/lib/ignore-styles.js
+++ b/lib/ignore-styles.js
@@ -4,7 +4,7 @@ exports.__esModule = true;
 exports.noOp = noOp;
 exports.restore = restore;
 exports.default = register;
-var DEFAULT_EXTENSIONS = exports.DEFAULT_EXTENSIONS = ['.css', '.scss', '.sass', '.pcss', '.stylus', '.styl', '.less', '.gif', '.jpeg', '.jpg', '.png', '.svg', '.mp4', '.webm', '.ogv'];
+var DEFAULT_EXTENSIONS = exports.DEFAULT_EXTENSIONS = ['.css', '.scss', '.sass', '.pcss', '.stylus', '.styl', '.less', '.sss', '.gif', '.jpeg', '.jpg', '.png', '.svg', '.mp4', '.webm', '.ogv'];
 
 var oldHandlers = exports.oldHandlers = {};
 


### PR DESCRIPTION
https://github.com/postcss/sugarss
SugarSS is a indent-based syntax like Sass or Stylus for PostCSS. Default extention is `.sss`
