### PR TITLE
Fix for ES5 syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ register(['.sass', '.scss'])
 To customize the extensions in ES5:
 
 ```js
-require('ignore-styles')(['.sass', '.scss'])
+require('ignore-styles').register(['.sass', '.scss'])
 ```
 
 ## Custom handler

--- a/lib/ignore-styles.js
+++ b/lib/ignore-styles.js
@@ -3,7 +3,7 @@
 exports.__esModule = true;
 exports.noOp = noOp;
 exports.restore = restore;
-exports.default = register;
+exports.default = exports.register = register;
 var DEFAULT_EXTENSIONS = exports.DEFAULT_EXTENSIONS = ['.css', '.scss', '.sass', '.pcss', '.stylus', '.styl', '.less', '.gif', '.jpeg', '.jpg', '.png', '.svg', '.mp4', '.webm', '.ogv'];
 
 var oldHandlers = exports.oldHandlers = {};


### PR DESCRIPTION
Thank you for your awesome work!

I read readme and tried to use this library in ES5 syntax, but it did not work. There was a difference between library and readme, so I fixed it.
