### PR TITLE
Use module.exports instead of returning filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,12 @@ Another use case would be to simply return the filename of an image so that it
 can be verified in unit tests:
 
 ```js
+const _ = require('lodash');
+const path = require('path');
+
 register(undefined, (module, filename) => {
   if (_.some(['.png', '.jpg'], ext => filename.endsWith(ext))) {
-    return path.basename(filename)
+    module.exports = path.basename(filename);
   }
 })
 ```


### PR DESCRIPTION
Returning the desired export doesn't actually work. Noticed this due to: https://github.com/bkonkle/ignore-styles/issues/9

Also added imports for the other modules, just so it's clear those are not globals. Would be happy to switch to ES6 modules if you'd prefer that.

Thanks!
