### PR TITLE
Feature: Pass the old handler to the new one

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ can be verified in unit tests:
 const _ = require('lodash');
 const path = require('path');
 
-register(undefined, (module, filename) => {
+register(undefined, (module, filename, oldHandler) => {
   if (_.some(['.png', '.jpg'], ext => filename.endsWith(ext))) {
     module.exports = path.basename(filename);
   }

--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ register(undefined, () => ({styleName: 'fake_class_name'}))
 ```
 
 The first argument to `register` is the list of extensions to handle. Leaving it
-undefined, as above, uses the default list. The handler function receives two arguments, `module` and `filename`, directly
-from Node.
+undefined, as above, uses the default list. The handler function receives three arguments, `module` and `filename`, directly
+from Node, and `oldHandler` which is the handler that was may be previously bound to the processed extension.
 
 Why is this useful? One example is when using something like
 [react-css-modules][react-css-modules]. You need the style imports to actually

--- a/ignore-styles.js
+++ b/ignore-styles.js
@@ -37,8 +37,11 @@ export default function register (extensions = DEFAULT_EXTENSIONS, handler = noO
   restore()
 
   for (const ext of extensions) {
-    oldHandlers[ext] = require.extensions[ext]
-    require.extensions[ext] = handler
+    const oldHandler = require.extensions[ext]
+    oldHandlers[ext] = oldHandler
+    require.extensions[ext] = function (module, filename) {
+      return handler(module, filename, oldHandler)
+    }
   }
 }
 


### PR DESCRIPTION
In my mocha configuration, I am trying to ignore the following import:
```javascript
import * as RepositoryWorker from "worker-loader!./repository.worker";
```
To match its extension, I need to pass a custom handler for `.js` like this:
```javascript
require('ignore-styles')
    .default(['.js'], function (module, filename) {
        // if worker-loader!./repository.worker, do something
    });
```
But I don't want to process every single imported js module myself. I just want to specifically process the unique problematic module. The rest of the `.js` modules must be handled as usual.

This PR adds a third argument to the handler, which is the replaced/old handler. This way, people can process a specific module themselves, and fallback to the old handler if necessary.